### PR TITLE
[WIP] allow middlewares to render custom statuses

### DIFF
--- a/test/integration/middleware_stack_test.rb
+++ b/test/integration/middleware_stack_test.rb
@@ -40,4 +40,13 @@ describe 'Middleware stack' do
 
     response.status.must_equal 404
   end
+
+  it 'returns a response body set by the middleware through for non-200 statuses' do
+    get '/legacy'
+
+    response.status.must_equal 404
+    response.body.must_equal 'legacy URL 404'
+
+    response.headers['X-Legacy-404'].must_equal 'true'
+  end
 end


### PR DESCRIPTION
This attempt tries to check if there's a response body before
attempting to render.

Fixes the specific case I was looking at, breaks loads of other stuff
